### PR TITLE
fix(deps): bump brace-expansion to 5.0.9 (CVE-2026-69152)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7099,9 +7099,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nanoid": "3.3.18",
     "js-yaml@3": "3.15.1",
     "js-yaml@4": "4.3.1",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "@babel/core": "7.29.6",
     "body-parser": "1.20.6",
     "fast-uri": "3.1.5",


### PR DESCRIPTION
## Summary

`svgo` **CVE-2026-73650** is already fixed on `main` (Dependabot alert #230, closed 2026-07-28). The lockfile pins `svgo@3.3.4`, which is the patched v3 release.

This PR clears the remaining open high Dependabot alert:

- Alert #243: **CVE-2026-69152** — `brace-expansion` DoS via unbounded intermediate arrays (`>= 4.0.0, < 5.0.9`)

## Change

Bump the existing npm override `brace-expansion` `5.0.8` → `5.0.9` and the matching lockfile entry.

`svgo` remains at `3.3.4`.